### PR TITLE
Add RUN_NODE_CACHE_PATH and RUN_NODE_ERROR_MSG variables

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -46,6 +46,23 @@ $ curl -sSLO https://github.com/sindresorhus/run-node/raw/master/run-node && chm
 ```
 ./run-node file.js
 ```
+### Add and edit customizable cache path and error message
+
+The cache path and error message are defined by ```RUN_NODE_CACHE_PATH``` and ```RUN_NODE_ERROR_MSG``` respectively. To add and edit this variables add this line to ```~.bashrc``` or ```~/.bash_profile```:
+
+```
+#node-run variables
+export RUN_NODE_ERROR_MSG="Custom error message"
+export RUN_NODE_CACHE_PATH="/custom/path/to/cache"
+```
+
+For example:
+
+```
+#node-run variables
+export RUN_NODE_ERROR_MSG="Node.js binary not found. Make sure you have installed Node.js"
+export RUN_NODE_CACHE_PATH="/home/username/.node_path"
+```
 
 
 ## Created by

--- a/readme.md
+++ b/readme.md
@@ -53,7 +53,6 @@ The cache path and error message are defined by `RUN_NODE_CACHE_PATH` and `RUN_N
 Default configuration:
 
 ```
-#node-run variables
 export RUN_NODE_ERROR_MSG="Couldn't find the Node.js binary. Ensure you have Node.js installed. Open an issue on https://github.com/sindresorhus/run-node"
 export RUN_NODE_CACHE_PATH="/home/username/.node_path"
 ```

--- a/readme.md
+++ b/readme.md
@@ -48,19 +48,13 @@ $ curl -sSLO https://github.com/sindresorhus/run-node/raw/master/run-node && chm
 ```
 ### Add and edit customizable cache path and error message
 
-The cache path and error message are defined by ```RUN_NODE_CACHE_PATH``` and ```RUN_NODE_ERROR_MSG``` respectively. To add and edit this variables add this line to ```~.bashrc``` or ```~/.bash_profile```:
+The cache path and error message are defined by `RUN_NODE_CACHE_PATH` and `RUN_NODE_ERROR_MSG` respectively. To add these variables to `~.bashrc` or `~/.bash_profile`. This variables can also be used in scripts that want to use set a different cache path or message.
+
+Default configuration:
 
 ```
 #node-run variables
-export RUN_NODE_ERROR_MSG="Custom error message"
-export RUN_NODE_CACHE_PATH="/custom/path/to/cache"
-```
-
-For example:
-
-```
-#node-run variables
-export RUN_NODE_ERROR_MSG="Node.js binary not found. Make sure you have installed Node.js"
+export RUN_NODE_ERROR_MSG="Couldn't find the Node.js binary. Ensure you have Node.js installed. Open an issue on https://github.com/sindresorhus/run-node"
 export RUN_NODE_CACHE_PATH="/home/username/.node_path"
 ```
 

--- a/readme.md
+++ b/readme.md
@@ -53,7 +53,7 @@ The cache path and error message are defined by the `RUN_NODE_CACHE_PATH` and `R
 
 Default config:
 
-```
+```sh
 export RUN_NODE_ERROR_MSG="Couldn't find the Node.js binary. Ensure you have Node.js installed. Open an issue on https://github.com/sindresorhus/run-node"
 export RUN_NODE_CACHE_PATH="/home/username/.node_path"
 ```

--- a/readme.md
+++ b/readme.md
@@ -46,11 +46,12 @@ $ curl -sSLO https://github.com/sindresorhus/run-node/raw/master/run-node && chm
 ```
 ./run-node file.js
 ```
-### Add and edit customizable cache path and error message
 
-The cache path and error message are defined by `RUN_NODE_CACHE_PATH` and `RUN_NODE_ERROR_MSG` respectively. To add these variables to `~.bashrc` or `~/.bash_profile`. This variables can also be used in scripts that want to use set a different cache path or message.
+#### Customizable cache path and error message
 
-Default configuration:
+The cache path and error message are defined by the `RUN_NODE_CACHE_PATH` and `RUN_NODE_ERROR_MSG` environment variables. You could use them in a script or add them to your `~.bashrc`.
+
+Default config:
 
 ```
 export RUN_NODE_ERROR_MSG="Couldn't find the Node.js binary. Ensure you have Node.js installed. Open an issue on https://github.com/sindresorhus/run-node"

--- a/run-node
+++ b/run-node
@@ -13,7 +13,7 @@ get_user_path() {
 }
 
 set_path() {
-	if [ -f "$PATH_CACHE" ]; then
+	if [[ -f "$PATH_CACHE" ]]; then
 		. "$PATH_CACHE"
 	else
 		get_user_path
@@ -41,7 +41,7 @@ fi
 if has_node; then
 	node "$@"
 else
-	if [ -z $RUN_NODE_ERROR_MSG ]; then
+	if [[ -z $RUN_NODE_ERROR_MSG ]]; then
 		echo "Couldn't find the Node.js binary. Ensure you have Node.js installed. Open an issue on https://github.com/sindresorhus/run-node"
  	else
  		echo "$RUN_NODE_ERROR_MSG"

--- a/run-node
+++ b/run-node
@@ -1,7 +1,11 @@
 #!/bin/bash
 # MIT License © Sindre Sorhus
 
-PATH_CACHE="$HOME"/.node_path
+if [[ -z $RUN_NODE_CACHE_PATH ]]; then
+	PATH_CACHE="$HOME"/.node_path
+else
+	PATH_CACHE="$RUN_NODE_CACHE_PATH"
+fi
 
 get_user_path() {
 	[[ -x "/usr/libexec/path_helper" ]] && eval $(/usr/libexec/path_helper -s)
@@ -9,7 +13,7 @@ get_user_path() {
 }
 
 set_path() {
-	if [[ -f "$PATH_CACHE" ]]; then
+	if [ -f "$PATH_CACHE" ]; then
 		. "$PATH_CACHE"
 	else
 		get_user_path
@@ -37,5 +41,9 @@ fi
 if has_node; then
 	node "$@"
 else
-	echo "Couldn't find the Node.js binary. Ensure you have Node.js installed. Open an issue on https://github.com/sindresorhus/run-node"
+	if [ -z $RUN_NODE_ERROR_MSG ]; then
+		echo "Couldn't find the Node.js binary. Ensure you have Node.js installed. Open an issue on https://github.com/sindresorhus/run-node"
+ 	else
+ 		echo "$RUN_NODE_ERROR_MSG"
+ 	fi
 fi


### PR DESCRIPTION
- Customizing cache path and error message is now possible. I chose to add environment variables for this solution.
    - I also thought about having a configuration file where these variables would be defined, otherwise defining these variables has to be done by editing ```~.bashrc```  or ```~/.bash_profile```, but it didn't sound a big of a problem to edit this files, and adding another file to the project would just increase complexity in the script, so i kept it simple.

- The readme file has been updated explaining the usage for this. If something isn't explicit let me know.