### PR TITLE
change bash to sh

### DIFF
--- a/run-node
+++ b/run-node
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # MIT License © Sindre Sorhus
 
 if [[ -z $RUN_NODE_CACHE_PATH ]]; then


### PR DESCRIPTION
Remove dependency on **bash** to run-node

**Reasons**
- bash might not be present inside **/bin/bash** on some systems. e.g. **FreeBSD** while _/bin/sh_ is.
- bash essentially started out as a sh compatible shell.