### PR TITLE
Use `/usr/bin/env` to run bash

### DIFF
--- a/run-node
+++ b/run-node
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # MIT License © Sindre Sorhus
 
 if [[ -z $RUN_NODE_CACHE_PATH ]]; then


### PR DESCRIPTION
Not all Unix/Linux environments keep bash within `/bin` (NixOS, for one) so if we make use of `env` we can ensure that bash can be run without issue.