### PR TITLE
Support the use of Node.js as an npm dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "run-node",
-	"version": "1.0.0",
+	"version": "2.0.0",
 	"description": "Run the Node.js binary no matter what",
 	"license": "MIT",
 	"repository": "sindresorhus/run-node",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "run-node",
-	"version": "2.0.0",
+	"version": "1.0.0",
 	"description": "Run the Node.js binary no matter what",
 	"license": "MIT",
 	"repository": "sindresorhus/run-node",

--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
 
 > Run the Node.js binary no matter what
 
-You can't always assume running `$ node file.js` will just work. The user might have the `node` binary in a non-standard location. They might be using a Node.js version manager like `nvm`, which is sourced in a subshell and not available from the outside. It also depends from where you're trying to run it. For example, GUI apps on macOS doesn't inherit the [`$PATH`](https://en.wikipedia.org/wiki/PATH_(variable)), so the `node` binary would not be found. Most projects that depend on Node.js just end up telling the user to manually set the full path to the `node` binary in some project specific settings. Now every project has to do this. [Ugh...](https://gist.github.com/cookrn/4015437) I prefer things to *just* work. With this module it will.
+You can't always assume running `$ node file.js` will just work. The user might have the `node` binary in a non-standard location. They might be using a Node.js version manager like `nvm`, which is sourced in a subshell and not available from the outside. Or they might have `node` installed as a local dependency in an npm project. It also depends from where you're trying to run it. For example, GUI apps on macOS doesn't inherit the [`$PATH`](https://en.wikipedia.org/wiki/PATH_(variable)), so the `node` binary would not be found. Most projects that depend on Node.js just end up telling the user to manually set the full path to the `node` binary in some project specific settings. Now every project has to do this. [Ugh...](https://gist.github.com/cookrn/4015437) I prefer things to *just* work. With this module it will.
 
 This Bash script uses some tricks to find the Node.js binary on your system and run it.
 
@@ -31,6 +31,8 @@ Or in an [npm run script](https://docs.npmjs.com/cli/run-script):
 }
 ```
 
+If the [`node`](https://www.npmjs.com/package/node) package is found in the local `node_modules` directory (for instance, if you have it installed as a [devDependency](https://docs.npmjs.com/files/package.json#devdependencies) of your npm project), this is the `node` binary that will be used.
+
 ### Manually
 
 #### Install
@@ -58,6 +60,7 @@ export RUN_NODE_ERROR_MSG="Couldn't find the Node.js binary. Ensure you have Nod
 export RUN_NODE_CACHE_PATH="/home/username/.node_path"
 ```
 
+If the `RUN_NODE_CACHE_PATH` variable is defined explicitly, the script it points will be sourced before looking for a `node` binary. You can use this script to override your `PATH` variable so that a specific `node` binary is found.
 
 ## Maintainers
 

--- a/readme.md
+++ b/readme.md
@@ -60,7 +60,7 @@ export RUN_NODE_ERROR_MSG="Couldn't find the Node.js binary. Ensure you have Nod
 export RUN_NODE_CACHE_PATH="/home/username/.node_path"
 ```
 
-If the `RUN_NODE_CACHE_PATH` variable is defined explicitly, the script it points will be sourced before looking for a `node` binary. You can use this script to override your `PATH` variable so that a specific `node` binary is found.
+If the `RUN_NODE_CACHE_PATH` environment variable is defined explicitly, the script it points to will be sourced before looking for a `node` binary. You can use this script to override your `PATH` variable so that a specific `node` binary is found.
 
 ## Maintainers
 

--- a/run-node
+++ b/run-node
@@ -13,7 +13,7 @@ else
 	if [[ -f "$PATH_CACHE" ]]; then
 		. "$PATH_CACHE"
 		export PATH
-    fi
+	fi
 fi
 
 get_user_path() {

--- a/run-node
+++ b/run-node
@@ -1,12 +1,24 @@
 #!/usr/bin/env bash
 # MIT License © Sindre Sorhus
 
+if [[ -f "$PWD/node_modules/node/bin/node" ]]; then
+	PATH="$PWD/node_modules/node/bin:$PATH"
+	export PATH
+fi
+
 if [[ -z $RUN_NODE_CACHE_PATH ]]; then
-	PATH_CACHE="$HOME"/.node_path
+	if [[ -f "./.node_path" ]]; then
+		PATH_CACHE="./.node_path"
+		. "$PATH_CACHE"
+		export PATH
+    else
+	    PATH_CACHE="$HOME"/.node_path
+    fi
 else
 	PATH_CACHE="$RUN_NODE_CACHE_PATH"
 	if [[ -f "$PATH_CACHE" ]]; then
 		. "$PATH_CACHE"
+		export PATH
     fi
 fi
 
@@ -30,7 +42,6 @@ has_node() {
 	command -v node >/dev/null 2>&1
 }
 
-# Check if we have node, otherwise inherit path from user shell
 if ! has_node; then
 	set_path
 

--- a/run-node
+++ b/run-node
@@ -7,13 +7,7 @@ if [[ -f "$PWD/node_modules/node/bin/node" ]]; then
 fi
 
 if [[ -z $RUN_NODE_CACHE_PATH ]]; then
-	if [[ -f "./.node_path" ]]; then
-		PATH_CACHE="./.node_path"
-		. "$PATH_CACHE"
-		export PATH
-    else
-	    PATH_CACHE="$HOME"/.node_path
-    fi
+	PATH_CACHE="$HOME"/.node_path
 else
 	PATH_CACHE="$RUN_NODE_CACHE_PATH"
 	if [[ -f "$PATH_CACHE" ]]; then
@@ -57,7 +51,7 @@ if has_node; then
 else
 	if [[ -z $RUN_NODE_ERROR_MSG ]]; then
 		echo "Couldn't find the Node.js binary. Ensure you have Node.js installed. Open an issue on https://github.com/sindresorhus/run-node"
- 	else
- 		echo "$RUN_NODE_ERROR_MSG"
- 	fi
+	else
+		echo "$RUN_NODE_ERROR_MSG"
+	fi
 fi

--- a/run-node
+++ b/run-node
@@ -5,6 +5,9 @@ if [[ -z $RUN_NODE_CACHE_PATH ]]; then
 	PATH_CACHE="$HOME"/.node_path
 else
 	PATH_CACHE="$RUN_NODE_CACHE_PATH"
+	if [[ -f "$PATH_CACHE" ]]; then
+		. "$PATH_CACHE"
+    fi
 fi
 
 get_user_path() {


### PR DESCRIPTION
A common pattern in npm projects is to specify node as a dependency or devDependency in order to make sure that npm scripts are run with the desired node version. Changes in this pull request will prioritize looking for the presence of an installed `./node_modules/node` dependency and use that version if found. I propose that this is the preferred behavior for users, but it is technically breaking backward compatibility because existing uses that happen to have node installed as a dependency will now behave differently.

Two other changes are also rolled into this PR, though they could be separated if they aren't desired. One is that if `RUN_NODE_CACHE_PATH` is defined and the specified path cache file exists, then it is sourced immediately, instead of waiting to see if node is already found on the existing path. This allows a user to use the env var to override the system path with a custom path cache, which is helpful if their PATH already contains a node executable, but not the one they want to us.

The other change is to allow for a local `.node_path` file which can also be used to override the system path to use a specific node version: if this file is present (and `RUN_NODE_CACHE_PATH` is _not_ defined), it will likewise be sourced immediately before checking for the presence of a node command.